### PR TITLE
Make external links open in new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }} {{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener noreferrer" {{ end }}> {{ .Text | safeHTML }} </a>


### PR DESCRIPTION
Could someone pls test this, I can't be bothered to install hugo. Should check that external links open in new tab and internal ones don't.

The snippet is from https://discourse.gohugo.io/t/open-external-links-in-new-tab-window/34000/21